### PR TITLE
[DO NOT MERGE] Example implementation of GreedyMerge

### DIFF
--- a/lib/OptimalBranchingCore/src/OptimalBranchingCore.jl
+++ b/lib/OptimalBranchingCore/src/OptimalBranchingCore.jl
@@ -30,5 +30,5 @@ include("interfaces.jl")
 include("branching_table.jl")
 include("setcovering.jl")
 include("branch.jl")
-
+include("greedymerge.jl")
 end

--- a/lib/OptimalBranchingCore/src/branch.jl
+++ b/lib/OptimalBranchingCore/src/branch.jl
@@ -73,7 +73,7 @@ function branch_and_reduce(problem::AbstractProblem, config::BranchingStrategy, 
     variables = select_variables(rp, config.measure, config.selector)  # select a subset of variables
     tbl = branching_table(rp, config.table_solver, variables)      # compute the BranchingTable
     result = optimal_branching_rule(tbl, variables, rp, config.measure, config.set_cover_solver)  # compute the optimal branching rule
-    return sum(result.optimal_rule.clauses) do branch  # branch and recurse
+    return sum(get_clauses(result)) do branch  # branch and recurse
         subproblem, localvalue = apply_branch(rp, branch, variables)
         branch_and_reduce(subproblem, config, reducer, result_type) * result_type(localvalue) * reducedvalue
     end

--- a/lib/OptimalBranchingCore/src/branch.jl
+++ b/lib/OptimalBranchingCore/src/branch.jl
@@ -15,9 +15,14 @@ A [`OptimalBranchingResult`](@ref) object representing the optimal branching rul
 """
 function optimal_branching_rule(table::BranchingTable, variables::Vector, problem::AbstractProblem, m::AbstractMeasure, solver::AbstractSetCoverSolver)
     candidates = candidate_clauses(table)
-    size_reductions = [size_reduction(problem,m,candidate,variables) for candidate in candidates]
-    return minimize_γ(table, candidates, size_reductions, solver; γ0=2.0)
+    size_reductions = [size_reduction(problem, m, candidate, variables) for candidate in candidates]
+    return minimize_γ(table, candidates, size_reductions, solver; γ0 = 2.0)
 end
+
+function size_reduction(p::AbstractProblem, m::AbstractMeasure, cl::Clause{INT}, variables::Vector) where {INT}
+    return measure(p, m) - measure(first(apply_branch(p, cl, variables)), m)
+end
+
 
 """
     BranchingStrategy
@@ -31,20 +36,20 @@ A struct representing the configuration for a solver, including the reducer and 
 - `selector::AbstractSelector`: The selector to select the next branching variable or decision.
 - `m::AbstractMeasure`: The measure to evaluate the performance of the branching strategy.
 """
-@kwdef struct BranchingStrategy{TS<:AbstractTableSolver, SCS<:AbstractSetCoverSolver, SL<:AbstractSelector, M<:AbstractMeasure}
+@kwdef struct BranchingStrategy{TS <: AbstractTableSolver, SCS <: AbstractSetCoverSolver, SL <: AbstractSelector, M <: AbstractMeasure}
     set_cover_solver::SCS = IPSolver()
     table_solver::TS
     selector::SL
     measure::M
 end
-Base.show(io::IO, config::BranchingStrategy) = print(io, 
-"""
-BranchingStrategy
-├── table_solver - $(config.table_solver)
-├── set_cover_solver - $(config.set_cover_solver)
-├── selector - $(config.selector)
-└── measure - $(config.measure)
-""")
+Base.show(io::IO, config::BranchingStrategy) = print(io,
+    """
+    BranchingStrategy
+    ├── table_solver - $(config.table_solver)
+    ├── set_cover_solver - $(config.set_cover_solver)
+    ├── selector - $(config.selector)
+    └── measure - $(config.measure)
+    """)
 
 """
     branch_and_reduce(problem::AbstractProblem, config::BranchingStrategy; reducer::AbstractReducer=NoReducer(), result_type=Int)

--- a/lib/OptimalBranchingCore/src/branch.jl
+++ b/lib/OptimalBranchingCore/src/branch.jl
@@ -15,7 +15,7 @@ A [`OptimalBranchingResult`](@ref) object representing the optimal branching rul
 """
 function optimal_branching_rule(table::BranchingTable, variables::Vector, problem::AbstractProblem, m::AbstractMeasure, solver::AbstractSetCoverSolver)
     candidates = candidate_clauses(table)
-    size_reductions = [measure(problem, m) - measure(first(apply_branch(problem, candidate, variables)), m) for candidate in candidates]
+    size_reductions = [size_reduction(problem,m,candidate,variables) for candidate in candidates]
     return minimize_γ(table, candidates, size_reductions, solver; γ0=2.0)
 end
 

--- a/lib/OptimalBranchingCore/src/greedymerge.jl
+++ b/lib/OptimalBranchingCore/src/greedymerge.jl
@@ -23,6 +23,9 @@ function greedymerge(cls::Vector{Vector{Clause{INT}}}, problem::AbstractProblem,
 			for ii in 1:length(cls[i]), jj in 1:length(cls[j])
 				if bdistance(cls[i][ii], cls[j][jj]) == 1
 					cl12 = gather2(n, cls[i][ii], cls[j][jj])
+                    if cl12.mask == 0
+                        continue
+                    end
 					l12 = size_reduction(problem,m,cl12,variables)
 					if γ^(-size_reductions[i]) + γ^(-size_reductions[j]) >= γ^(-l12) + 1e-8
 						push!(cls, [cl12])

--- a/lib/OptimalBranchingCore/src/greedymerge.jl
+++ b/lib/OptimalBranchingCore/src/greedymerge.jl
@@ -1,0 +1,49 @@
+struct GreedyMerge <: AbstractSetCoverSolver end
+function optimal_branching_rule(table::BranchingTable, variables::Vector, problem::AbstractProblem, m::AbstractMeasure, solver::GreedyMerge)
+	candidates = bit_clauses(table)
+	return greedymerge(candidates, problem, variables, m)
+end
+
+function bit_clauses(tbl::BranchingTable{INT}) where {INT}
+	n, bss = tbl.bit_length, tbl.table
+	temp_clauses = [[Clause(bmask(INT, 1:n), bs) for bs in bss1] for bss1 in bss]
+	return temp_clauses
+end
+
+function greedymerge(cls::Vector{Vector{Clause{INT}}}, problem::AbstractProblem, variables::Vector,m::AbstractMeasure) where {INT}
+	active_cls = collect(1:length(cls))
+	cls = copy(cls)
+	merging_pairs = [(i, j) for i in active_cls, j in active_cls if i < j]
+    n = length(variables)
+	size_reductions = [size_reduction(problem,m,candidate[1],variables) for candidate in cls]
+    γ = complexity_bv(size_reductions)
+	while !isempty(merging_pairs)
+		i, j = popfirst!(merging_pairs)
+		if i in active_cls && j in active_cls
+			for ii in 1:length(cls[i]), jj in 1:length(cls[j])
+				if bdistance(cls[i][ii], cls[j][jj]) == 1
+					cl12 = gather2(n, cls[i][ii], cls[j][jj])
+					l12 = size_reduction(problem,m,cl12,variables)
+					if γ^(-size_reductions[i]) + γ^(-size_reductions[j]) >= γ^(-l12) + 1e-8
+						push!(cls, [cl12])
+						k = length(cls)
+						deleteat!(active_cls, findfirst(==(i), active_cls))
+						deleteat!(active_cls, findfirst(==(j), active_cls))
+						for ii in active_cls
+							push!(merging_pairs, (ii, k))
+						end
+						push!(active_cls, k)
+						push!(size_reductions, l12)
+                        γ = complexity_bv(size_reductions[active_cls])
+						break
+					end
+				end
+			end
+		end
+	end
+    return [cl[1] for cl in cls[active_cls]]
+end
+
+function size_reduction(p::AbstractProblem, m::AbstractMeasure, cl::Clause{INT}, variables::Vector) where {INT}
+    return measure(p, m) - measure(first(apply_branch(p, cl, variables)), m)
+end

--- a/lib/OptimalBranchingCore/src/greedymerge.jl
+++ b/lib/OptimalBranchingCore/src/greedymerge.jl
@@ -21,32 +21,26 @@ function greedymerge(cls::Vector{Vector{Clause{INT}}}, problem::AbstractProblem,
 		i, j = popfirst!(merging_pairs)
 		if i in active_cls && j in active_cls
 			for ii in 1:length(cls[i]), jj in 1:length(cls[j])
-				if bdistance(cls[i][ii], cls[j][jj]) == 1
-					cl12 = gather2(n, cls[i][ii], cls[j][jj])
-					if cl12.mask == 0
-						continue
-					end
-					l12 = size_reduction(problem, m, cl12, variables)
-					if γ^(-size_reductions[i]) + γ^(-size_reductions[j]) >= γ^(-l12) + 1e-8
-						push!(cls, [cl12])
-						k = length(cls)
-						deleteat!(active_cls, findfirst(==(i), active_cls))
-						deleteat!(active_cls, findfirst(==(j), active_cls))
-						for ii in active_cls
-							push!(merging_pairs, (ii, k))
-						end
-						push!(active_cls, k)
-						push!(size_reductions, l12)
-						γ = complexity_bv(size_reductions[active_cls])
-						break
-					end
-				end
+                cl12 = gather2(n, cls[i][ii], cls[j][jj])
+                if cl12.mask == 0
+                    continue
+                end
+                l12 = size_reduction(problem, m, cl12, variables)
+                if γ^(-size_reductions[i]) + γ^(-size_reductions[j]) >= γ^(-l12) + 1e-12
+                    push!(cls, [cl12])
+                    k = length(cls)
+                    deleteat!(active_cls, findfirst(==(i), active_cls))
+                    deleteat!(active_cls, findfirst(==(j), active_cls))
+                    for ii in active_cls
+                        push!(merging_pairs, (ii, k))
+                    end
+                    push!(active_cls, k)
+                    push!(size_reductions, l12)
+                    γ = complexity_bv(size_reductions[active_cls])
+                    break
+                end
 			end
 		end
 	end
-	return [cl[1] for cl in cls[active_cls]]
-end
-
-function size_reduction(p::AbstractProblem, m::AbstractMeasure, cl::Clause{INT}, variables::Vector) where {INT}
-	return measure(p, m) - measure(first(apply_branch(p, cl, variables)), m)
+    return OptimalBranchingResult(DNF([cl[1] for cl in cls[active_cls]]), [size_reductions[i] for i in active_cls], γ)
 end

--- a/lib/OptimalBranchingCore/src/greedymerge.jl
+++ b/lib/OptimalBranchingCore/src/greedymerge.jl
@@ -10,23 +10,23 @@ function bit_clauses(tbl::BranchingTable{INT}) where {INT}
 	return temp_clauses
 end
 
-function greedymerge(cls::Vector{Vector{Clause{INT}}}, problem::AbstractProblem, variables::Vector,m::AbstractMeasure) where {INT}
+function greedymerge(cls::Vector{Vector{Clause{INT}}}, problem::AbstractProblem, variables::Vector, m::AbstractMeasure) where {INT}
 	active_cls = collect(1:length(cls))
 	cls = copy(cls)
 	merging_pairs = [(i, j) for i in active_cls, j in active_cls if i < j]
-    n = length(variables)
-	size_reductions = [size_reduction(problem,m,candidate[1],variables) for candidate in cls]
-    γ = complexity_bv(size_reductions)
+	n = length(variables)
+	size_reductions = [size_reduction(problem, m, candidate[1], variables) for candidate in cls]
+	γ = complexity_bv(size_reductions)
 	while !isempty(merging_pairs)
 		i, j = popfirst!(merging_pairs)
 		if i in active_cls && j in active_cls
 			for ii in 1:length(cls[i]), jj in 1:length(cls[j])
 				if bdistance(cls[i][ii], cls[j][jj]) == 1
 					cl12 = gather2(n, cls[i][ii], cls[j][jj])
-                    if cl12.mask == 0
-                        continue
-                    end
-					l12 = size_reduction(problem,m,cl12,variables)
+					if cl12.mask == 0
+						continue
+					end
+					l12 = size_reduction(problem, m, cl12, variables)
 					if γ^(-size_reductions[i]) + γ^(-size_reductions[j]) >= γ^(-l12) + 1e-8
 						push!(cls, [cl12])
 						k = length(cls)
@@ -37,16 +37,16 @@ function greedymerge(cls::Vector{Vector{Clause{INT}}}, problem::AbstractProblem,
 						end
 						push!(active_cls, k)
 						push!(size_reductions, l12)
-                        γ = complexity_bv(size_reductions[active_cls])
+						γ = complexity_bv(size_reductions[active_cls])
 						break
 					end
 				end
 			end
 		end
 	end
-    return [cl[1] for cl in cls[active_cls]]
+	return [cl[1] for cl in cls[active_cls]]
 end
 
 function size_reduction(p::AbstractProblem, m::AbstractMeasure, cl::Clause{INT}, variables::Vector) where {INT}
-    return measure(p, m) - measure(first(apply_branch(p, cl, variables)), m)
+	return measure(p, m) - measure(first(apply_branch(p, cl, variables)), m)
 end

--- a/lib/OptimalBranchingCore/src/setcovering.jl
+++ b/lib/OptimalBranchingCore/src/setcovering.jl
@@ -113,6 +113,8 @@ struct OptimalBranchingResult{INT <: Integer, T <: Real}
     γ::Float64
 end
 Base.show(io::IO, results::OptimalBranchingResult{INT, T}) where {INT, T} = print(io, "OptimalBranchingResult{$INT, $T}:\n selected_ids: $(results.selected_ids)\n optimal_rule: $(results.optimal_rule)\n branching_vector: $(results.branching_vector)\n γ: $(results.γ)")
+get_clauses(results::OptimalBranchingResult) = results.optimal_rule.clauses
+get_clauses(res::AbstractArray) = res
 
 """
     minimize_γ(table::BranchingTable, candidates::Vector{Clause}, Δρ::Vector, solver)

--- a/lib/OptimalBranchingCore/src/setcovering.jl
+++ b/lib/OptimalBranchingCore/src/setcovering.jl
@@ -101,18 +101,16 @@ end
 The result type for the optimal branching rule.
 
 ### Fields
-- `selected_ids::Vector{Int}`: The indices of the selected rows in the branching table.
 - `optimal_rule::DNF{INT}`: The optimal branching rule.
 - `branching_vector::Vector{T<:Real}`: The branching vector that records the size reduction in each subproblem.
 - `γ::Float64`: The optimal γ value (the complexity of the branching rule).
 """
 struct OptimalBranchingResult{INT <: Integer, T <: Real}
-    selected_ids::Vector{Int}
     optimal_rule::DNF{INT}
     branching_vector::Vector{T}
     γ::Float64
 end
-Base.show(io::IO, results::OptimalBranchingResult{INT, T}) where {INT, T} = print(io, "OptimalBranchingResult{$INT, $T}:\n selected_ids: $(results.selected_ids)\n optimal_rule: $(results.optimal_rule)\n branching_vector: $(results.branching_vector)\n γ: $(results.γ)")
+Base.show(io::IO, results::OptimalBranchingResult{INT, T}) where {INT, T} = print(io, "OptimalBranchingResult{$INT, $T}:\n optimal_rule: $(results.optimal_rule)\n branching_vector: $(results.branching_vector)\n γ: $(results.γ)")
 get_clauses(results::OptimalBranchingResult) = results.optimal_rule.clauses
 get_clauses(res::AbstractArray) = res
 
@@ -142,7 +140,7 @@ function minimize_γ(table::BranchingTable, candidates::Vector{Clause{INT}}, Δ�
 
     # Note: the following instance is captured for time saving, and also for it may cause IP solver to fail
     for (k, subset) in enumerate(subsets)
-        (length(subset) == num_items) && return OptimalBranchingResult([k], DNF([candidates[k]]), [Δρ[k]], 1.0)
+        (length(subset) == num_items) && return OptimalBranchingResult(DNF([candidates[k]]), [Δρ[k]], 1.0)
     end
 
     cx_old = cx = γ0
@@ -155,7 +153,7 @@ function minimize_γ(table::BranchingTable, candidates::Vector{Clause{INT}}, Δ�
         cx ≈ cx_old && break  # convergence
         cx_old = cx
     end
-    return OptimalBranchingResult(picked_scs, DNF([candidates[i] for i in picked_scs]), Δρ[picked_scs], cx)
+    return OptimalBranchingResult(DNF([candidates[i] for i in picked_scs]), Δρ[picked_scs], cx)
 end
 
 # TODO: we need to extend this function to trim the candidate clauses

--- a/lib/OptimalBranchingCore/test/branching_table.jl
+++ b/lib/OptimalBranchingCore/test/branching_table.jl
@@ -1,5 +1,5 @@
 using OptimalBranchingCore, GenericTensorNetworks
-using BitBasis
+using OptimalBranchingCore.BitBasis
 using Test
 
 @testset "branching table" begin

--- a/lib/OptimalBranchingCore/test/greedymerge.jl
+++ b/lib/OptimalBranchingCore/test/greedymerge.jl
@@ -1,0 +1,15 @@
+using Test
+using OptimalBranchingCore
+using OptimalBranchingCore: bit_clauses
+using OptimalBranchingCore.BitBasis
+using GenericTensorNetworks
+
+@testset "bit_clauses" begin
+	tbl = BranchingTable(5, [
+		[StaticElementVector(2, [0, 0, 1, 0, 0]), StaticElementVector(2, [0, 1, 0, 0, 0])],
+		[StaticElementVector(2, [1, 0, 0, 1, 0])],
+		[StaticElementVector(2, [0, 0, 1, 0, 1])],
+	])
+
+	bc = bit_clauses(tbl)
+end

--- a/lib/OptimalBranchingCore/test/setcovering.jl
+++ b/lib/OptimalBranchingCore/test/setcovering.jl
@@ -16,7 +16,6 @@ end
     Δρ = [count_ones(c.mask) for c in clauses]
     result_ip = OptimalBranchingCore.minimize_γ(tbl, clauses, Δρ, IPSolver(; max_itr = 10, verbose = false))
     result_lp = OptimalBranchingCore.minimize_γ(tbl, clauses, Δρ, LPSolver(; max_itr = 10, verbose = false))
-    @test result_ip.selected_ids == result_lp.selected_ids
     @test result_ip.branching_vector ≈ result_lp.branching_vector
     @test result_ip.γ ≈ result_lp.γ ≈ 1.0
 
@@ -29,7 +28,6 @@ end
     Δρ = [count_ones(c.mask) for c in clauses]
     result_ip = OptimalBranchingCore.minimize_γ(tbl, clauses, Δρ, IPSolver(; max_itr = 10, verbose = false))
     result_lp = OptimalBranchingCore.minimize_γ(tbl, clauses, Δρ, LPSolver(; max_itr = 10, verbose = false))
-    @test result_ip.selected_ids == result_lp.selected_ids
     @test result_ip.branching_vector ≈ result_lp.branching_vector
     @test result_ip.γ ≈ result_lp.γ ≈ 1.1673039782614185
 
@@ -47,7 +45,6 @@ end
     Δρ = [count_ones(c.mask) for c in clauses]
     result_ip = OptimalBranchingCore.minimize_γ(tbl, clauses, Δρ, IPSolver(max_itr = 10, verbose = false))
     result_lp = OptimalBranchingCore.minimize_γ(tbl, clauses, Δρ, LPSolver(max_itr = 10, verbose = false))
-    @test result_ip.selected_ids == result_lp.selected_ids
     @test result_ip.branching_vector ≈ result_lp.branching_vector
     @test OptimalBranchingCore.covered_by(tbl, result_ip.optimal_rule)
     @test OptimalBranchingCore.covered_by(tbl, result_lp.optimal_rule)

--- a/lib/OptimalBranchingCore/test/setcovering.jl
+++ b/lib/OptimalBranchingCore/test/setcovering.jl
@@ -66,3 +66,35 @@ end
     @test OptimalBranchingCore.covered_by(tbl, result_ip.optimal_rule)
     @test result_ip.γ ≈ 1.0
 end
+
+@testset "covered_by" begin
+    tbl = BranchingTable(9, [
+        [[0,0,0,0,0,1,1,0,0], [0,0,0,0,0,0,1,1,0]],
+        [[0,0,0,0,1,1,1,0,0]],
+        [[0,0,1,1,0,0,0,0,1], [0,0,1,1,0,1,0,0,0], [0,0,1,1,0,0,0,1,0]],
+        [[0,0,1,1,1,0,0,0,1], [0,0,1,1,1,1,0,0,0]],
+        [[0,1,0,0,0,0,1,1,0]],
+        [[0,1,0,1,1,0,0,0,1]],
+        [[0,1,1,0,1,0,0,0,1]],
+        [[0,1,1,1,0,0,0,0,1], [0,1,1,1,0,0,0,1,0]],
+        [[0,1,1,1,1,0,0,0,1]],
+        [[1,0,0,0,0,0,1,1,0]],
+        [[1,0,0,1,1,0,0,0,1]],
+        [[1,0,1,0,1,0,0,0,1]],
+        [[1,0,1,1,0,0,0,0,1], [1,0,1,1,0,0,0,1,0]],
+        [[1,0,1,1,1,0,0,0,1]],
+        [[1,1,0,0,0,0,1,1,0]],
+        [[1,1,0,1,1,0,0,0,1]],
+        [[1,1,1,0,1,0,0,0,1]],
+        [[1,1,1,1,0,0,0,0,1], [1,1,1,1,0,0,0,1,0]],
+        [[1,1,1,1,1,0,0,0,1]]
+    ])
+    clauses = OptimalBranchingCore.candidate_clauses(tbl)
+    Δρ = [count_ones(c.mask) for c in clauses]
+    result_ip = OptimalBranchingCore.minimize_γ(tbl, clauses, Δρ, IPSolver(max_itr = 10, verbose = false))
+    @test OptimalBranchingCore.covered_by(tbl, result_ip.optimal_rule)
+
+    cls = OptimalBranchingCore.bit_clauses(tbl)
+    clsf = OptimalBranchingCore.greedymerge(cls, p, [1, 2, 3, 4, 5], D3Measure())
+    @test OptimalBranchingCore.covered_by(tbl, DNF(clsf))
+end

--- a/lib/OptimalBranchingCore/test/setcovering.jl
+++ b/lib/OptimalBranchingCore/test/setcovering.jl
@@ -66,35 +66,3 @@ end
     @test OptimalBranchingCore.covered_by(tbl, result_ip.optimal_rule)
     @test result_ip.γ ≈ 1.0
 end
-
-@testset "covered_by" begin
-    tbl = BranchingTable(9, [
-        [[0,0,0,0,0,1,1,0,0], [0,0,0,0,0,0,1,1,0]],
-        [[0,0,0,0,1,1,1,0,0]],
-        [[0,0,1,1,0,0,0,0,1], [0,0,1,1,0,1,0,0,0], [0,0,1,1,0,0,0,1,0]],
-        [[0,0,1,1,1,0,0,0,1], [0,0,1,1,1,1,0,0,0]],
-        [[0,1,0,0,0,0,1,1,0]],
-        [[0,1,0,1,1,0,0,0,1]],
-        [[0,1,1,0,1,0,0,0,1]],
-        [[0,1,1,1,0,0,0,0,1], [0,1,1,1,0,0,0,1,0]],
-        [[0,1,1,1,1,0,0,0,1]],
-        [[1,0,0,0,0,0,1,1,0]],
-        [[1,0,0,1,1,0,0,0,1]],
-        [[1,0,1,0,1,0,0,0,1]],
-        [[1,0,1,1,0,0,0,0,1], [1,0,1,1,0,0,0,1,0]],
-        [[1,0,1,1,1,0,0,0,1]],
-        [[1,1,0,0,0,0,1,1,0]],
-        [[1,1,0,1,1,0,0,0,1]],
-        [[1,1,1,0,1,0,0,0,1]],
-        [[1,1,1,1,0,0,0,0,1], [1,1,1,1,0,0,0,1,0]],
-        [[1,1,1,1,1,0,0,0,1]]
-    ])
-    clauses = OptimalBranchingCore.candidate_clauses(tbl)
-    Δρ = [count_ones(c.mask) for c in clauses]
-    result_ip = OptimalBranchingCore.minimize_γ(tbl, clauses, Δρ, IPSolver(max_itr = 10, verbose = false))
-    @test OptimalBranchingCore.covered_by(tbl, result_ip.optimal_rule)
-
-    cls = OptimalBranchingCore.bit_clauses(tbl)
-    clsf = OptimalBranchingCore.greedymerge(cls, p, [1, 2, 3, 4, 5], D3Measure())
-    @test OptimalBranchingCore.covered_by(tbl, DNF(clsf))
-end

--- a/lib/OptimalBranchingMIS/src/interfaces.jl
+++ b/lib/OptimalBranchingMIS/src/interfaces.jl
@@ -1,37 +1,37 @@
 """
-    mis_size(g::AbstractGraph; bs::BranchingStrategy = BranchingStrategy(table_solver = TensorNetworkSolver(), selector = MinBoundaryHighDegreeSelector(2, 6, 0), measure=D3Measure()), reducer::AbstractReducer = MISReducer())
+    mis_size(g::AbstractGraph; branching_strategy::BranchingStrategy = BranchingStrategy(table_solver = TensorNetworkSolver(), selector = MinBoundaryHighDegreeSelector(2, 6, 0), measure=D3Measure()), reducer::AbstractReducer = MISReducer())
 
 Calculate the size of the Maximum Independent Set (MIS) for a given graph.
 
 ### Arguments
 - `g::AbstractGraph`: The graph for which the MIS size is to be calculated.
-- `bs::BranchingStrategy`: (optional) The branching strategy to be used. Defaults to a strategy using `table_solver=TensorNetworkSolver`, `selector=MinBoundaryHighDegreeSelector(2, 6, 0)`, and `measure=D3Measure`.
+- `branching_strategy::BranchingStrategy`: (optional) The branching strategy to be used. Defaults to a strategy using `table_solver=TensorNetworkSolver`, `selector=MinBoundaryHighDegreeSelector(2, 6, 0)`, and `measure=D3Measure`.
 - `reducer::AbstractReducer`: (optional) The reducer to be applied. Defaults to `MISReducer`.
 
 ### Returns
 - An integer representing the size of the Maximum Independent Set for the given graph.
 """
-function mis_size(g::AbstractGraph; bs::BranchingStrategy = BranchingStrategy(table_solver = TensorNetworkSolver(), selector = MinBoundaryHighDegreeSelector(2, 6, 0), measure=D3Measure()), reducer=MISReducer())
+function mis_size(g::AbstractGraph; branching_strategy::BranchingStrategy = BranchingStrategy(table_solver = TensorNetworkSolver(), selector = MinBoundaryHighDegreeSelector(2, 6, 0), measure = D3Measure()), reducer = MISReducer())
     p = MISProblem(g)
-    res = branch_and_reduce(p, bs, reducer, MaxSize)
+    res = branch_and_reduce(p, branching_strategy, reducer, MaxSize)
     return res.size
 end
 
 """
-    mis_branch_count(g::AbstractGraph; bs::BranchingStrategy = BranchingStrategy(table_solver = TensorNetworkSolver(), selector = MinBoundaryHighDegreeSelector(2, 6, 0), measure=D3Measure()), reducer=MISReducer())
+    mis_branch_count(g::AbstractGraph; branching_strategy::BranchingStrategy = BranchingStrategy(table_solver = TensorNetworkSolver(), selector = MinBoundaryHighDegreeSelector(2, 6, 0), measure=D3Measure()), reducer=MISReducer())
 
 Calculate the size and the number of branches of the Maximum Independent Set (MIS) for a given graph.
 
 ### Arguments
 - `g::AbstractGraph`: The graph for which the MIS size and the number of branches are to be calculated.
-- `bs::BranchingStrategy`: (optional) The branching strategy to be used. Defaults to a strategy using `table_solver=TensorNetworkSolver`, `selector=MinBoundaryHighDegreeSelector(2, 6, 0)`, and `measure=D3Measure`.
+- `branching_strategy::BranchingStrategy`: (optional) The branching strategy to be used. Defaults to a strategy using `table_solver=TensorNetworkSolver`, `selector=MinBoundaryHighDegreeSelector(2, 6, 0)`, and `measure=D3Measure`.
 - `reducer::AbstractReducer`: (optional) The reducer to be applied. Defaults to `MISReducer`.
 
 ### Returns
 - A tuple `(size, count)` where `size` is the size of the Maximum Independent Set and `count` is the number of branches.
 """
-function mis_branch_count(g::AbstractGraph; bs::BranchingStrategy = BranchingStrategy(table_solver = TensorNetworkSolver(), selector = MinBoundaryHighDegreeSelector(2, 6, 0), measure=D3Measure()), reducer=MISReducer())
+function mis_branch_count(g::AbstractGraph; branching_strategy::BranchingStrategy = BranchingStrategy(table_solver = TensorNetworkSolver(), selector = MinBoundaryHighDegreeSelector(2, 6, 0), measure = D3Measure()), reducer = MISReducer())
     p = MISProblem(g)
-    res = branch_and_reduce(p, bs, reducer, MaxSizeBranchCount)
+    res = branch_and_reduce(p, branching_strategy, reducer, MaxSizeBranchCount)
     return (res.size, res.count)
 end

--- a/lib/OptimalBranchingMIS/src/interfaces.jl
+++ b/lib/OptimalBranchingMIS/src/interfaces.jl
@@ -30,8 +30,8 @@ Calculate the size and the number of branches of the Maximum Independent Set (MI
 ### Returns
 - A tuple `(size, count)` where `size` is the size of the Maximum Independent Set and `count` is the number of branches.
 """
-function mis_branch_count(g::AbstractGraph; branching_strategy::BranchingStrategy = BranchingStrategy(table_solver = TensorNetworkSolver(), selector = MinBoundaryHighDegreeSelector(2, 6, 0), measure=D3Measure()), reducer=MISReducer())
+function mis_branch_count(g::AbstractGraph; bs::BranchingStrategy = BranchingStrategy(table_solver = TensorNetworkSolver(), selector = MinBoundaryHighDegreeSelector(2, 6, 0), measure=D3Measure()), reducer=MISReducer())
     p = MISProblem(g)
-    res = branch_and_reduce(p, branching_strategy, reducer, MaxSizeBranchCount)
+    res = branch_and_reduce(p, bs, reducer, MaxSizeBranchCount)
     return (res.size, res.count)
 end

--- a/lib/OptimalBranchingMIS/src/types.jl
+++ b/lib/OptimalBranchingMIS/src/types.jl
@@ -84,3 +84,19 @@ function OptimalBranchingCore.measure(p::MISProblem, ::D3Measure)
         return Int(sum(max(d - 2, 0) for d in dg))
     end
 end
+
+function OptimalBranchingCore.size_reduction(p::MISProblem, m::D3Measure, cl::Clause{INT}, variables::Vector) where {INT}
+    vertices_removed = removed_vertices(variables, p.g, cl)
+    sum = 0
+    for v in vertices_removed
+        sum += max(degree(p.g, v) - 2, 0)
+    end
+    vertices_removed_neighbors =  setdiff(mapreduce( v->neighbors(p.g, v),∪,vertices_removed), vertices_removed)
+    for v in vertices_removed_neighbors
+        sum += max(degree(p.g, v) - 2 ) - max(degree(p.g, v) - 2 - count(vx -> vx ∈ vertices_removed,neighbors(p.g, v)), 0)
+    end
+    # @show sum
+    # old_sum =  measure(p, m) - measure(first(OptimalBranchingCore.apply_branch(p, cl, variables)), m)
+    # old_sum != sum && @show old_sum
+    return sum
+end

--- a/lib/OptimalBranchingMIS/src/types.jl
+++ b/lib/OptimalBranchingMIS/src/types.jl
@@ -1,5 +1,5 @@
 """
-    mutable struct MISProblem <: AbstractProblem
+	mutable struct MISProblem <: AbstractProblem
 
 Represents a Maximum Independent Set (MIS) problem.
 
@@ -12,25 +12,25 @@ Represents a Maximum Independent Set (MIS) problem.
 
 """
 mutable struct MISProblem <: AbstractProblem
-    g::SimpleGraph
+	g::SimpleGraph{Int}
 end
 Base.copy(p::MISProblem) = MISProblem(copy(p.g))
 Base.show(io::IO, p::MISProblem) = print(io, "MISProblem($(nv(p.g)))")
 Base.isempty(p::MISProblem) = nv(p.g) == 0
 
 """
-    TensorNetworkSolver
-    TensorNetworkSolver(; prune_by_env::Bool = true)
+	TensorNetworkSolver
+	TensorNetworkSolver(; prune_by_env::Bool = true)
 
 A struct representing a solver for tensor network problems. 
 This struct serves as a specific implementation of the `AbstractTableSolver` type.
 """
 @kwdef struct TensorNetworkSolver <: AbstractTableSolver
-    prune_by_env::Bool = true
+	prune_by_env::Bool = true
 end
 
 """
-    NumOfVertices
+	NumOfVertices
 
 A struct representing a measure that counts the number of vertices in a graph. 
 Each vertex is counted as 1.
@@ -41,7 +41,7 @@ Each vertex is counted as 1.
 struct NumOfVertices <: AbstractMeasure end
 
 """
-    measure(p::MISProblem, ::NumOfVertices)
+	measure(p::MISProblem, ::NumOfVertices)
 
 Calculates the number of vertices in the given `MISProblem`.
 
@@ -54,7 +54,7 @@ Calculates the number of vertices in the given `MISProblem`.
 OptimalBranchingCore.measure(p::MISProblem, ::NumOfVertices) = nv(p.g)
 
 """
-    D3Measure
+	D3Measure
 
 A struct representing a measure that calculates the sum of the maximum degree minus 2 for each vertex in the graph.
 
@@ -64,7 +64,7 @@ A struct representing a measure that calculates the sum of the maximum degree mi
 struct D3Measure <: AbstractMeasure end
 
 """
-    measure(p::MISProblem, ::D3Measure)
+	measure(p::MISProblem, ::D3Measure)
 
 Calculates the D3 measure for the given `MISProblem`, which is defined as the sum of 
 the maximum degree of each vertex minus 2, for all vertices in the graph.
@@ -76,27 +76,27 @@ the maximum degree of each vertex minus 2, for all vertices in the graph.
 - `Int`: The computed D3 measure value.
 """
 function OptimalBranchingCore.measure(p::MISProblem, ::D3Measure)
-    g = p.g
-    if nv(g) == 0
-        return 0
-    else
-        dg = degree(g)
-        return Int(sum(max(d - 2, 0) for d in dg))
-    end
+	g = p.g
+	if nv(g) == 0
+		return 0
+	else
+		dg = degree(g)
+		return Int(sum(max(d - 2, 0) for d in dg))
+	end
 end
 
 function OptimalBranchingCore.size_reduction(p::MISProblem, m::D3Measure, cl::Clause{INT}, variables::Vector) where {INT}
-    vertices_removed = removed_vertices(variables, p.g, cl)
-    sum = 0
-    for v in vertices_removed
-        sum += max(degree(p.g, v) - 2, 0)
-    end
-    vertices_removed_neighbors =  setdiff(mapreduce( v->neighbors(p.g, v),∪,vertices_removed), vertices_removed)
-    for v in vertices_removed_neighbors
-        sum += max(degree(p.g, v) - 2 ) - max(degree(p.g, v) - 2 - count(vx -> vx ∈ vertices_removed,neighbors(p.g, v)), 0)
-    end
-    # @show sum
-    # old_sum =  measure(p, m) - measure(first(OptimalBranchingCore.apply_branch(p, cl, variables)), m)
-    # old_sum != sum && @show old_sum
-    return sum
+	vertices_removed = removed_vertices(variables, p.g, cl)
+	sum = 0
+	for v in vertices_removed
+		sum += max(degree(p.g, v) - 2, 0)
+	end
+	vertices_removed_neighbors = setdiff(mapreduce(v -> neighbors(p.g, v), ∪, vertices_removed), vertices_removed)
+	for v in vertices_removed_neighbors
+		sum += max(degree(p.g, v) - 2) - max(degree(p.g, v) - 2 - count(vx -> vx ∈ vertices_removed, neighbors(p.g, v)), 0)
+	end
+	# @show sum
+	# old_sum =  measure(p, m) - measure(first(OptimalBranchingCore.apply_branch(p, cl, variables)), m)
+	# old_sum != sum && @show old_sum
+	return sum
 end

--- a/lib/OptimalBranchingMIS/src/types.jl
+++ b/lib/OptimalBranchingMIS/src/types.jl
@@ -87,6 +87,7 @@ end
 
 function OptimalBranchingCore.size_reduction(p::MISProblem, m::D3Measure, cl::Clause{INT}, variables::Vector) where {INT}
     vertices_removed = removed_vertices(variables, p.g, cl)
+    isempty(vertices_removed) && return 0
     sum = 0
     for v in vertices_removed
         sum += max(degree(p.g, v) - 2, 0)

--- a/lib/OptimalBranchingMIS/src/types.jl
+++ b/lib/OptimalBranchingMIS/src/types.jl
@@ -1,5 +1,5 @@
 """
-	mutable struct MISProblem <: AbstractProblem
+mutable struct MISProblem <: AbstractProblem
 
 Represents a Maximum Independent Set (MIS) problem.
 
@@ -12,25 +12,25 @@ Represents a Maximum Independent Set (MIS) problem.
 
 """
 mutable struct MISProblem <: AbstractProblem
-	g::SimpleGraph{Int}
+    g::SimpleGraph{Int}
 end
 Base.copy(p::MISProblem) = MISProblem(copy(p.g))
 Base.show(io::IO, p::MISProblem) = print(io, "MISProblem($(nv(p.g)))")
 Base.isempty(p::MISProblem) = nv(p.g) == 0
 
 """
-	TensorNetworkSolver
-	TensorNetworkSolver(; prune_by_env::Bool = true)
+TensorNetworkSolver
+TensorNetworkSolver(; prune_by_env::Bool = true)
 
 A struct representing a solver for tensor network problems. 
 This struct serves as a specific implementation of the `AbstractTableSolver` type.
 """
 @kwdef struct TensorNetworkSolver <: AbstractTableSolver
-	prune_by_env::Bool = true
+    prune_by_env::Bool = true
 end
 
 """
-	NumOfVertices
+NumOfVertices
 
 A struct representing a measure that counts the number of vertices in a graph. 
 Each vertex is counted as 1.
@@ -41,7 +41,7 @@ Each vertex is counted as 1.
 struct NumOfVertices <: AbstractMeasure end
 
 """
-	measure(p::MISProblem, ::NumOfVertices)
+measure(p::MISProblem, ::NumOfVertices)
 
 Calculates the number of vertices in the given `MISProblem`.
 
@@ -54,7 +54,7 @@ Calculates the number of vertices in the given `MISProblem`.
 OptimalBranchingCore.measure(p::MISProblem, ::NumOfVertices) = nv(p.g)
 
 """
-	D3Measure
+D3Measure
 
 A struct representing a measure that calculates the sum of the maximum degree minus 2 for each vertex in the graph.
 
@@ -64,7 +64,7 @@ A struct representing a measure that calculates the sum of the maximum degree mi
 struct D3Measure <: AbstractMeasure end
 
 """
-	measure(p::MISProblem, ::D3Measure)
+measure(p::MISProblem, ::D3Measure)
 
 Calculates the D3 measure for the given `MISProblem`, which is defined as the sum of 
 the maximum degree of each vertex minus 2, for all vertices in the graph.
@@ -76,27 +76,24 @@ the maximum degree of each vertex minus 2, for all vertices in the graph.
 - `Int`: The computed D3 measure value.
 """
 function OptimalBranchingCore.measure(p::MISProblem, ::D3Measure)
-	g = p.g
-	if nv(g) == 0
-		return 0
-	else
-		dg = degree(g)
-		return Int(sum(max(d - 2, 0) for d in dg))
-	end
+    g = p.g
+    if nv(g) == 0
+        return 0
+    else
+        dg = degree(g)
+        return Int(sum(max(d - 2, 0) for d in dg))
+    end
 end
 
 function OptimalBranchingCore.size_reduction(p::MISProblem, m::D3Measure, cl::Clause{INT}, variables::Vector) where {INT}
-	vertices_removed = removed_vertices(variables, p.g, cl)
-	sum = 0
-	for v in vertices_removed
-		sum += max(degree(p.g, v) - 2, 0)
-	end
-	vertices_removed_neighbors = setdiff(mapreduce(v -> neighbors(p.g, v), ∪, vertices_removed), vertices_removed)
-	for v in vertices_removed_neighbors
-		sum += max(degree(p.g, v) - 2) - max(degree(p.g, v) - 2 - count(vx -> vx ∈ vertices_removed, neighbors(p.g, v)), 0)
-	end
-	# @show sum
-	# old_sum =  measure(p, m) - measure(first(OptimalBranchingCore.apply_branch(p, cl, variables)), m)
-	# old_sum != sum && @show old_sum
-	return sum
+    vertices_removed = removed_vertices(variables, p.g, cl)
+    sum = 0
+    for v in vertices_removed
+        sum += max(degree(p.g, v) - 2, 0)
+    end
+    vertices_removed_neighbors = setdiff(mapreduce(v -> neighbors(p.g, v), ∪, vertices_removed), vertices_removed)
+    for v in vertices_removed_neighbors
+        sum += max(degree(p.g, v) - 2) - max(degree(p.g, v) - 2 - count(vx -> vx ∈ vertices_removed, neighbors(p.g, v)), 0)
+    end
+    return sum
 end

--- a/lib/OptimalBranchingMIS/test/greedymerge.jl
+++ b/lib/OptimalBranchingMIS/test/greedymerge.jl
@@ -8,36 +8,35 @@ using GenericTensorNetworks
 using OptimalBranchingCore: bit_clauses
 Random.seed!(1234)
 
+# Example from arXiv:2412.07685 Fig. 1
 @testset "GreedyMerge" begin
-	edges = [(1, 4), (1, 5), (3, 4), (2, 5), (4, 5), (1, 6), (2, 7), (3, 8)]
-	example_g = SimpleGraph(Graphs.SimpleEdge.(edges))
-	p = MISProblem(example_g)
-	tbl = BranchingTable(5, [
-		[StaticElementVector(2, [0, 0, 0, 0, 1]), StaticElementVector(2, [0, 0, 0, 1, 0])],
-		[StaticElementVector(2, [0, 0, 1, 0, 1])],
-		[StaticElementVector(2, [0, 1, 0, 1, 0])],
-		[StaticElementVector(2, [1, 1, 1, 0, 0])],
-	])
-	cls = bit_clauses(tbl)
-	clsf = OptimalBranchingCore.greedymerge(cls, p, [1, 2, 3, 4, 5], D3Measure())
-	@test clsf[1].mask == cls[3][1].mask
-	@test clsf[1].val == cls[3][1].val
-	@test clsf[2].mask == cls[4][1].mask
-	@test clsf[2].val == cls[4][1].val
-	@test clsf[3].mask == 27
-	@test clsf[3].val == 16
+    edges = [(1, 4), (1, 5), (3, 4), (2, 5), (4, 5), (1, 6), (2, 7), (3, 8)]
+    example_g = SimpleGraph(Graphs.SimpleEdge.(edges))
+    p = MISProblem(example_g)
+    tbl = BranchingTable(5, [
+        [StaticElementVector(2, [0, 0, 0, 0, 1]), StaticElementVector(2, [0, 0, 0, 1, 0])],
+        [StaticElementVector(2, [0, 0, 1, 0, 1])],
+        [StaticElementVector(2, [0, 1, 0, 1, 0])],
+        [StaticElementVector(2, [1, 1, 1, 0, 0])],
+    ])
+    cls = bit_clauses(tbl)
+    clsf = OptimalBranchingCore.greedymerge(cls, p, [1, 2, 3, 4, 5], D3Measure())
+    @test clsf[1].mask == cls[3][1].mask
+    @test clsf[1].val == cls[3][1].val
+    @test clsf[2].mask == cls[4][1].mask
+    @test clsf[2].val == cls[4][1].val
+    @test clsf[3].mask == 27
+    @test clsf[3].val == 16
 end
 
-@testset "mis" begin
-	for _num in 60:10:100
-		g = random_regular_graph(_num, 3)
-        reducer = NoReducer()
-		bs = BranchingStrategy(table_solver = TensorNetworkSolver(), selector = MinBoundaryHighDegreeSelector(2, 6, 0), measure = D3Measure(), set_cover_solver = OptimalBranchingCore.GreedyMerge())
-		mis1,count1 = mis_branch_count(g; bs, reducer)
-        mis2,count2 = mis_branch_count(g;reducer)
-        if mis1 != mis2 
-            println("g")
+@testset "GreedyMerge" begin
+    g = random_regular_graph(20, 3)
+    mis_num, count2 = mis_branch_count(g)
+    for reducer in [NoReducer(), MISReducer()]
+        for measure in [D3Measure(), NumOfVertices()]
+            bs = BranchingStrategy(table_solver = TensorNetworkSolver(), selector = MinBoundaryHighDegreeSelector(2, 6, 0), measure = measure, set_cover_solver = OptimalBranchingCore.GreedyMerge())
+            mis1, count1 = mis_branch_count(g; branching_strategy = bs, reducer)
+            @test mis1 == mis_num
         end
-        @show count1,count2
-	end
+    end
 end

--- a/lib/OptimalBranchingMIS/test/greedymerge.jl
+++ b/lib/OptimalBranchingMIS/test/greedymerge.jl
@@ -1,0 +1,45 @@
+using OptimalBranchingMIS
+using OptimalBranchingMIS.EliminateGraphs.Graphs
+using Test
+using Random
+using OptimalBranchingCore
+using OptimalBranchingCore.BitBasis
+using GenericTensorNetworks
+using OptimalBranchingCore: bit_clauses
+Random.seed!(1234)
+
+@testset "GreedyMerge" begin
+	edges = [(1, 4), (1, 5), (3, 4), (2, 5), (4, 5), (1, 6), (2, 7), (3, 8)]
+	example_g = SimpleGraph(Graphs.SimpleEdge.(edges))
+	p = MISProblem(example_g)
+	tbl = BranchingTable(5, [
+		[StaticElementVector(2, [0, 0, 0, 0, 1]), StaticElementVector(2, [0, 0, 0, 1, 0])],
+		[StaticElementVector(2, [0, 0, 1, 0, 1])],
+		[StaticElementVector(2, [0, 1, 0, 1, 0])],
+		[StaticElementVector(2, [1, 1, 1, 0, 0])],
+	])
+	cls = bit_clauses(tbl)
+	clsf = OptimalBranchingCore.greedymerge(cls, p, [1, 2, 3, 4, 5], D3Measure())
+	@test clsf[1].mask == cls[3][1].mask
+	@test clsf[1].val == cls[3][1].val
+	@test clsf[2].mask == cls[4][1].mask
+	@test clsf[2].val == cls[4][1].val
+	@test clsf[3].mask == 27
+	@test clsf[3].val == 16
+end
+
+@testset "mis" begin
+    num = 10
+	for _ in 1:num
+		g = random_regular_graph(60, 3)
+
+		bs = BranchingStrategy(table_solver = TensorNetworkSolver(), selector = MinBoundaryHighDegreeSelector(2, 6, 0), measure = D3Measure(), set_cover_solver = OptimalBranchingCore.GreedyMerge())
+		mis1,count1 = mis_branch_count(g; bs)
+        mis2,count2 = mis_branch_count(g)
+        if mis1 != mis2 
+            println("g")
+        end
+        @show count1,count2
+	end
+
+end

--- a/lib/OptimalBranchingMIS/test/greedymerge.jl
+++ b/lib/OptimalBranchingMIS/test/greedymerge.jl
@@ -29,17 +29,15 @@ Random.seed!(1234)
 end
 
 @testset "mis" begin
-    num = 10
-	for _ in 1:num
-		g = random_regular_graph(60, 3)
-
+	for _num in 60:10:100
+		g = random_regular_graph(_num, 3)
+        reducer = NoReducer()
 		bs = BranchingStrategy(table_solver = TensorNetworkSolver(), selector = MinBoundaryHighDegreeSelector(2, 6, 0), measure = D3Measure(), set_cover_solver = OptimalBranchingCore.GreedyMerge())
-		mis1,count1 = mis_branch_count(g; bs)
-        mis2,count2 = mis_branch_count(g)
+		mis1,count1 = mis_branch_count(g; bs, reducer)
+        mis2,count2 = mis_branch_count(g;reducer)
         if mis1 != mis2 
             println("g")
         end
         @show count1,count2
 	end
-
 end

--- a/lib/OptimalBranchingMIS/test/types.jl
+++ b/lib/OptimalBranchingMIS/test/types.jl
@@ -1,0 +1,15 @@
+using OptimalBranchingMIS
+using OptimalBranchingMIS.EliminateGraphs.Graphs
+using Test
+using Random
+using OptimalBranchingCore
+using OptimalBranchingCore.BitBasis
+using GenericTensorNetworks
+using OptimalBranchingCore: size_reduction
+
+@testset "size_reduction" begin
+    g = random_regular_graph(60, 3)
+    vs = collect(1:20)
+    cl = Clause(bit"1111111111", bit"1011010111")
+    size_reduction(MISProblem(g),D3Measure(),cl,vs)
+end

--- a/lib/OptimalBranchingMIS/test/types.jl
+++ b/lib/OptimalBranchingMIS/test/types.jl
@@ -5,11 +5,13 @@ using Random
 using OptimalBranchingCore
 using OptimalBranchingCore.BitBasis
 using GenericTensorNetworks
-using OptimalBranchingCore: size_reduction
+using OptimalBranchingCore: size_reduction, apply_branch
 
 @testset "size_reduction" begin
     g = random_regular_graph(60, 3)
     vs = collect(1:20)
     cl = Clause(bit"1111111111", bit"1011010111")
-    size_reduction(MISProblem(g),D3Measure(),cl,vs)
+    p = MISProblem(g)
+    m = D3Measure()
+    @test size_reduction(p, m, cl, vs) == measure(p, m) - measure(first(apply_branch(p, cl, vs)), m)
 end

--- a/lib/OptimalBranchingMIS/test/types.jl
+++ b/lib/OptimalBranchingMIS/test/types.jl
@@ -15,3 +15,37 @@ using OptimalBranchingCore: size_reduction, apply_branch
     m = D3Measure()
     @test size_reduction(p, m, cl, vs) == measure(p, m) - measure(first(apply_branch(p, cl, vs)), m)
 end
+
+
+@testset "covered_by" begin
+    tbl = BranchingTable(9, [
+        [[0,0,0,0,0,1,1,0,0], [0,0,0,0,0,0,1,1,0]],
+        [[0,0,0,0,1,1,1,0,0]],
+        [[0,0,1,1,0,0,0,0,1], [0,0,1,1,0,1,0,0,0], [0,0,1,1,0,0,0,1,0]],
+        [[0,0,1,1,1,0,0,0,1], [0,0,1,1,1,1,0,0,0]],
+        [[0,1,0,0,0,0,1,1,0]],
+        [[0,1,0,1,1,0,0,0,1]],
+        [[0,1,1,0,1,0,0,0,1]],
+        [[0,1,1,1,0,0,0,0,1], [0,1,1,1,0,0,0,1,0]],
+        [[0,1,1,1,1,0,0,0,1]],
+        [[1,0,0,0,0,0,1,1,0]],
+        [[1,0,0,1,1,0,0,0,1]],
+        [[1,0,1,0,1,0,0,0,1]],
+        [[1,0,1,1,0,0,0,0,1], [1,0,1,1,0,0,0,1,0]],
+        [[1,0,1,1,1,0,0,0,1]],
+        [[1,1,0,0,0,0,1,1,0]],
+        [[1,1,0,1,1,0,0,0,1]],
+        [[1,1,1,0,1,0,0,0,1]],
+        [[1,1,1,1,0,0,0,0,1], [1,1,1,1,0,0,0,1,0]],
+        [[1,1,1,1,1,0,0,0,1]]
+    ])
+    clauses = OptimalBranchingCore.candidate_clauses(tbl)
+    Δρ = [count_ones(c.mask) for c in clauses]
+    result_ip = OptimalBranchingCore.minimize_γ(tbl, clauses, Δρ, IPSolver(max_itr = 10, verbose = false))
+    @test OptimalBranchingCore.covered_by(tbl, result_ip.optimal_rule)
+
+    p = MISProblem(random_regular_graph(20, 3))
+    cls = OptimalBranchingCore.bit_clauses(tbl)
+    clsf = OptimalBranchingCore.greedymerge(cls, p, [1, 2, 3, 4, 5], D3Measure())
+    @test OptimalBranchingCore.covered_by(tbl, DNF(clsf))
+end


### PR DESCRIPTION
@nzy1997 The previous implementation does not merge clauses correctly. Please check this one.

The MWE:
```julia
# # Automatic rule discovery
using OptimalBranching.OptimalBranchingMIS.Graphs, OptimalBranching
using OptimalBranching.OptimalBranchingCore, OptimalBranching.OptimalBranchingCore.BitBasis

# This function generates the tree-like N3 neighborhood of g0.
function tree_like_N3_neighborhood(g0::SimpleGraph)
    g = copy(g0)
    for layer in 1:3
        for v in vertices(g)
            for _ = 1:(3-degree(g, v))
                add_vertex!(g)
                add_edge!(g, v, nv(g))
            end
        end
    end
    return g
end

# ## Bottleneck case
# Define the branching region R
vs = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22]
edges = [(1, 2), (1, 3), (1, 4), (2, 5), (2, 6), (3, 7), (3, 8), (4, 9), (4, 10), (5, 11), (5, 12), (6, 13), (6, 14), (7, 15), (7, 16), (8, 17), (8, 18), (9, 19), (9, 20), (10, 21), (10, 22), (11, 14), (12, 13), (15, 18), (16, 17), (19, 22), (20, 21)]
branching_region = SimpleGraph(Graphs.SimpleEdge.(edges)) 

# Generate the tree-like N3 neighborhood of R
graph = tree_like_N3_neighborhood(branching_region)

# ## Generating rules for large scale problems
# For large scale problems, we can use the greedy merge rule to generate rules, which avoids generating all candidate clauses.
function solve_greedy_rule(branching_region, graph, vs)
    ## Use default solver and measure
    m = D3Measure()
    table_solver = TensorNetworkSolver(; prune_by_env=true)

    ## Pruning irrelevant entries
    ovs = OptimalBranchingMIS.open_vertices(graph, vs)
    subg, vmap = induced_subgraph(graph, vs)
    @info "solving the branching table..."
    tbl = OptimalBranchingMIS.reduced_alpha_configs(table_solver, subg, Int[findfirst(==(v), vs) for v in ovs])
    @info "the length of the truth_table after pruning irrelevant entries: $(length(tbl.table))"

    @info "generating the optimal branching rule via greedy merge..."
    # greedymerge(cls::Vector{Vector{Clause{INT}}}, problem::AbstractProblem, variables::Vector, m::AbstractMeasure) where {INT}
    candidates = OptimalBranchingCore.bit_clauses(tbl)
    result = OptimalBranchingMIS.OptimalBranchingCore.greedymerge(candidates, MISProblem(graph), vs, m)
    @info "the greedily minimized gamma: $(result.γ)"

    @info "the branching rule on R:"
    viz_dnf(result.optimal_rule, vs)
end

result = solve_greedy_rule(branching_region, graph, vs)
```

Example output:
```julia
julia> result = solve_greedy_rule(branching_region, graph, vs)
[ Info: solving the branching table...
[ Info: the length of the truth_table after pruning irrelevant entries: 71
[ Info: generating the optimal branching rule via greedy merge...
[ Info: the greedily minimized gamma: 1.0842073740067577
[ Info: the branching rule on R:
1 ∧ ¬2 ∧ ¬3 ∧ ¬4 ∧ 5 ∧ ¬6 ∧ 7 ∧ ¬8 ∧ 9 ∧ ¬10 ∧ ¬11 ∧ ¬12 ∧ 13 ∧ 14 ∧ ¬15 ∧ ¬16 ∧ 17 ∧ 18 ∧ ¬19 ∧ ¬20 ∧ 21 ∧ 22
1 ∧ ¬2 ∧ ¬3 ∧ ¬4 ∧ 6 ∧ 8 ∧ 10 ∧ ¬13 ∧ ¬14 ∧ ¬17 ∧ ¬18 ∧ ¬21 ∧ ¬22
1 ∧ ¬2 ∧ ¬3 ∧ ¬4 ∧ 5 ∧ ¬6 ∧ 8 ∧ 10 ∧ ¬11 ∧ ¬12 ∧ 13 ∧ 14 ∧ ¬17 ∧ ¬18 ∧ ¬21 ∧ ¬22
1 ∧ ¬2 ∧ ¬3 ∧ ¬4 ∧ 6 ∧ 7 ∧ ¬8 ∧ 10 ∧ ¬13 ∧ ¬14 ∧ ¬15 ∧ ¬16 ∧ 17 ∧ 18 ∧ ¬21 ∧ ¬22
1 ∧ ¬2 ∧ ¬3 ∧ ¬4 ∧ 6 ∧ 8 ∧ 9 ∧ ¬10 ∧ ¬13 ∧ ¬14 ∧ ¬17 ∧ ¬18 ∧ ¬19 ∧ ¬20 ∧ 21 ∧ 22
1 ∧ ¬2 ∧ ¬3 ∧ ¬4 ∧ 5 ∧ ¬6 ∧ 7 ∧ ¬8 ∧ 10 ∧ ¬11 ∧ ¬12 ∧ 13 ∧ 14 ∧ ¬15 ∧ ¬16 ∧ 17 ∧ 18 ∧ ¬21 ∧ ¬22
1 ∧ ¬2 ∧ ¬3 ∧ ¬4 ∧ 5 ∧ ¬6 ∧ 8 ∧ 9 ∧ ¬10 ∧ ¬11 ∧ ¬12 ∧ 13 ∧ 14 ∧ ¬17 ∧ ¬18 ∧ ¬19 ∧ ¬20 ∧ 21 ∧ 22
1 ∧ ¬2 ∧ ¬3 ∧ ¬4 ∧ 6 ∧ 7 ∧ ¬8 ∧ 9 ∧ ¬10 ∧ ¬13 ∧ ¬14 ∧ ¬15 ∧ ¬16 ∧ 17 ∧ 18 ∧ ¬19 ∧ ¬20 ∧ 21 ∧ 22
¬1 ∧ 2 ∧ 3 ∧ ¬5 ∧ ¬6 ∧ ¬7 ∧ ¬8
¬1 ∧ 2 ∧ ¬3 ∧ 4 ∧ ¬5 ∧ ¬6 ∧ 8 ∧ ¬9 ∧ ¬10 ∧ ¬17 ∧ ¬18
¬1 ∧ ¬2 ∧ 3 ∧ 4 ∧ 6 ∧ ¬7 ∧ ¬8 ∧ ¬9 ∧ ¬10 ∧ ¬13 ∧ ¬14
```