### PR TITLE
New: Set cover preprocessor

### DIFF
--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+OptimalBranching = "96e750e4-2b4b-404e-96bc-6769eb2ae924"
+SCIP = "82193955-e24f-5292-bf16-6f2c5261a85f"

--- a/examples/rule_discovery.jl
+++ b/examples/rule_discovery.jl
@@ -20,7 +20,7 @@ function solve_opt_rule(branching_region, graph, vs)
     ## Use default solver and measure
     m = D3Measure()
     table_solver = TensorNetworkSolver(; prune_by_env=true)
-    set_cover_solver = IPSolver()
+    set_cover_solver = IPSolver(verbose=true)
 
     ## Pruning irrelevant entries
     ovs = OptimalBranchingMIS.open_vertices(graph, vs)

--- a/examples/rule_discovery.jl
+++ b/examples/rule_discovery.jl
@@ -1,6 +1,7 @@
 # # Automatic rule discovery
 using OptimalBranching.OptimalBranchingMIS.Graphs, OptimalBranching
 using OptimalBranching.OptimalBranchingCore, OptimalBranching.OptimalBranchingCore.BitBasis
+using SCIP
 
 # This function generates the tree-like N3 neighborhood of g0.
 function tree_like_N3_neighborhood(g0::SimpleGraph)
@@ -20,7 +21,7 @@ function solve_opt_rule(branching_region, graph, vs)
     ## Use default solver and measure
     m = D3Measure()
     table_solver = TensorNetworkSolver(; prune_by_env=true)
-    set_cover_solver = IPSolver(verbose=true)
+    set_cover_solver = IPSolver(optimizer= SCIP.Optimizer, verbose=true)
 
     ## Pruning irrelevant entries
     ovs = OptimalBranchingMIS.open_vertices(graph, vs)

--- a/lib/OptimalBranchingMIS/Project.toml
+++ b/lib/OptimalBranchingMIS/Project.toml
@@ -14,7 +14,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [compat]
 Combinatorics = "1"
 EliminateGraphs = "0.2"
-GenericTensorNetworks = "3"
+GenericTensorNetworks = "3, 4"
 KaHyPar = "0.3.1"
 OptimalBranchingCore = "0.1.0"
 SparseArrays = "1.11.0"

--- a/lib/OptimalBranchingMIS/Project.toml
+++ b/lib/OptimalBranchingMIS/Project.toml
@@ -7,9 +7,14 @@ version = "0.1.1"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 EliminateGraphs = "b3ff564c-d3b6-11e9-0ef2-9b4ae9f9cbe1"
 GenericTensorNetworks = "3521c873-ad32-4bb4-b63d-f4f178f42b49"
-KaHyPar = "2a6221f6-aa48-11e9-3542-2d9e0ef01880"
 OptimalBranchingCore = "c76e7b22-e1d2-40e8-b0f1-f659837787b8"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[weakdeps]
+KaHyPar = "2a6221f6-aa48-11e9-3542-2d9e0ef01880"
+
+[extensions]
+KaHyParExt = "KaHyPar"
 
 [compat]
 Combinatorics = "1"
@@ -18,13 +23,11 @@ GenericTensorNetworks = "3, 4"
 KaHyPar = "0.3.1"
 OptimalBranchingCore = "0.1.0"
 SparseArrays = "1.11.0"
-TropicalGEMM = "0.2.0"
 julia = "1.10"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-TropicalGEMM = "a4ad3063-64a7-4bad-8738-34ed09bc0236"
 
 [targets]
-test = ["Random", "Test", "TropicalGEMM"]
+test = ["Random", "Test", "KaHyPar"]

--- a/lib/OptimalBranchingMIS/ext/KaHyParExt.jl
+++ b/lib/OptimalBranchingMIS/ext/KaHyParExt.jl
@@ -1,0 +1,47 @@
+module KaHyParExt
+
+using KaHyPar, OptimalBranchingMIS
+using OptimalBranchingMIS.OptimalBranchingCore
+using OptimalBranchingMIS.Graphs
+
+function OptimalBranchingCore.select_variables(p::MISProblem, m::M, selector::KaHyParSelector) where {M <: AbstractMeasure}
+    nv(p.g) <= selector.app_domain_size && return collect(1:nv(p.g))
+    h = KaHyPar.HyperGraph(OptimalBranchingMIS.edge2vertex(p))
+    imbalance = 1-2*selector.app_domain_size/nv(p.g)
+    
+    parts = KaHyPar.partition(h, 2; configuration = pkgdir(@__MODULE__, "src/ini", "cut_kKaHyPar_sea20.ini"), imbalance)
+
+    zero_num = count(x-> x ≈ 0,parts)
+    one_num = length(parts)-zero_num
+    @debug "Selecting vertices by KaHyPar, sizes: $(zero_num), $(one_num)"
+
+    return abs(zero_num-selector.app_domain_size) < abs(one_num-selector.app_domain_size) ? findall(iszero,parts) : findall(!iszero,parts)
+end
+
+# region selectors, max size is n_max and a vertex i is required to be in the region
+function OptimalBranchingMIS.select_region(g::AbstractGraph, i::Int, n_max::Int, strategy::Symbol)
+    if strategy == :neighbor
+        vs = [i]
+        while length(vs) < n_max
+            nbrs = OptimalBranchingMIS.open_neighbors(g, vs)
+            (length(vs) + length(nbrs) > n_max) && break
+            append!(vs, nbrs)
+        end
+        return vs
+    elseif strategy == :mincut
+        nv(g) <= n_max && return collect(1:nv(g))
+        h = KaHyPar.HyperGraph(OptimalBranchingMIS.edge2vertex(g))
+        
+        fix_vs = [j == i ? 1 : -1 for j in 1:nv(g)]
+        KaHyPar.fix_vertices(h, 2, fix_vs)
+        KaHyPar.set_target_block_weights(h, [nv(g) - n_max, n_max])
+        parts = KaHyPar.partition(h, 2; configuration = pkgdir(@__MODULE__, "src/ini", "cut_kKaHyPar_sea20.ini"))
+        
+        return findall(!iszero,parts)
+    else
+        error("Invalid strategy: $strategy, must be :neighbor or :mincut")
+    end
+end
+
+end
+

--- a/lib/OptimalBranchingMIS/src/OptimalBranchingMIS.jl
+++ b/lib/OptimalBranchingMIS/src/OptimalBranchingMIS.jl
@@ -7,11 +7,10 @@ using Combinatorics
 using EliminateGraphs, EliminateGraphs.Graphs
 using GenericTensorNetworks
 using SparseArrays
-using KaHyPar
 
 export MISProblem
 export MISReducer, XiaoReducer, TensorNetworkReducer
-export MinBoundarySelector, MinBoundaryHighDegreeSelector,KaHyParSelector
+export MinBoundarySelector, MinBoundaryHighDegreeSelector, KaHyParSelector
 export TensorNetworkSolver
 export NumOfVertices, D3Measure
 

--- a/lib/OptimalBranchingMIS/src/reducer.jl
+++ b/lib/OptimalBranchingMIS/src/reducer.jl
@@ -22,7 +22,8 @@ A reducer that uses tensor network contraction to find reduction rules.
 - `n_max::Int = 15`: Maximum number of vertices to be included in the selected region
 - `selector::Symbol = :mincut`: Strategy for selecting vertices to contract. Options are:
     - `:neighbor`: Select vertices based on neighborhood
-    - `:mincut`: Select vertices based on minimum cut provided by KaHyPar !Note: KaHyPar may leads to memory leak!
+    - `:mincut`: Select vertices based on minimum cut provided by `KaHyPar` (as extension, requires `using KaHyPar`)
+      !Note: `KaHyPar` may leads to memory leak!
 - `measure::AbstractMeasure = NumOfVertices()`: Measure used for kernelization. Uses size reduction from OptimalBranchingMIS
 - `intersect_strategy::Symbol = :bfs`: Strategy for intersecting clauses. Options are:
     - `:bfs`: Breadth-first search (gives the optimal result)
@@ -178,6 +179,10 @@ function reduce_graph(g::SimpleGraph{Int}, tnreducer::TensorNetworkReducer; vmap
     end
 
     return g, 0, collect(1:nv(g))
+end
+
+function select_region(args...)
+    error("Region selection requires `using KaHyPar`, since it is an extension function.")
 end
 
 #update the region_list accroding to the region list

--- a/lib/OptimalBranchingMIS/test/branch.jl
+++ b/lib/OptimalBranchingMIS/test/branch.jl
@@ -1,4 +1,5 @@
 using OptimalBranchingMIS, EliminateGraphs, EliminateGraphs.Graphs
+using KaHyPar
 using OptimalBranchingCore
 using Test, Random
 

--- a/lib/OptimalBranchingMIS/test/runtests.jl
+++ b/lib/OptimalBranchingMIS/test/runtests.jl
@@ -1,5 +1,4 @@
 using OptimalBranchingMIS
-using TropicalGEMM
 using Test
 
 @testset "branch" begin

--- a/lib/OptimalBranchingMIS/test/selector.jl
+++ b/lib/OptimalBranchingMIS/test/selector.jl
@@ -2,6 +2,7 @@ using Test
 using OptimalBranchingMIS
 using OptimalBranchingCore
 using OptimalBranchingMIS.Graphs
+using KaHyPar
 
 @testset "KaHyParSelector" begin
     g = random_regular_graph(20, 3; seed = 2134)


### PR DESCRIPTION
This may speedup the OB solving a bit (tested with HiGHS and SCIP).

## SCIP test result
Before:
```
[ Info: the minimized gamma: 1.081711631576666
[ Info: the optimal branching rule on R:
¬1 ∧ 2 ∧ 3 ∧ ¬5 ∧ ¬6 ∧ ¬7 ∧ ¬8
¬1 ∧ 4 ∧ ¬9 ∧ ¬10 ∧ ¬11 ∧ ¬13 ∧ ¬16 ∧ ¬18
1 ∧ ¬2 ∧ ¬3 ∧ ¬4
¬1 ∧ 4 ∧ ¬9 ∧ ¬10 ∧ ¬12 ∧ ¬14 ∧ ¬15 ∧ ¬17
  7.968167 seconds (9.50 M allocations: 844.244 MiB, 5.90% gc time)
```

After:
```
[ Info: the minimized gamma: 1.081711631576666
[ Info: the optimal branching rule on R:
1 ∧ ¬2 ∧ ¬3 ∧ ¬4
¬1 ∧ 3 ∧ 4 ∧ ¬7 ∧ ¬8 ∧ ¬9 ∧ ¬10
¬1 ∧ 2 ∧ ¬3 ∧ 4 ∧ ¬5 ∧ ¬6 ∧ 7 ∧ 8 ∧ ¬9 ∧ ¬10 ∧ ¬15 ∧ ¬16 ∧ ¬17 ∧ ¬18
¬1 ∧ 2 ∧ 3 ∧ ¬4 ∧ ¬5 ∧ ¬6 ∧ ¬7 ∧ ¬8 ∧ 9 ∧ 10 ∧ ¬19 ∧ ¬20 ∧ ¬21 ∧ ¬22
  6.795425 seconds (6.78 M allocations: 655.534 MiB, 1.90% gc time)
```

Other updates:
1. Move KaHyPar region selector to extension, since it is not compatible with SCIP!
2. Upgrade GenericTensorNetworks to version 4.