### PR TITLE
fix region selector

### DIFF
--- a/lib/OptimalBranchingMIS/src/reducer.jl
+++ b/lib/OptimalBranchingMIS/src/reducer.jl
@@ -32,7 +32,7 @@ A reducer that uses tensor network contraction to find reduction rules.
 """
 @kwdef mutable struct TensorNetworkReducer <: AbstractReducer
     n_max::Int = 15
-    selector::Symbol = :mincut # :neighbor or :mincut
+    selector::Symbol = :neighbor # :neighbor or :mincut
     measure::AbstractMeasure = NumOfVertices() # different measures for kernelization, use the size reduction from OptimalBranchingMIS
     intersect_strategy::Symbol = :bfs # :dfs or :bfs
     sub_reducer::AbstractReducer = XiaoReducer() # sub reducer for the selected vertices
@@ -181,7 +181,27 @@ function reduce_graph(g::SimpleGraph{Int}, tnreducer::TensorNetworkReducer; vmap
     return g, 0, collect(1:nv(g))
 end
 
-function select_region(args...)
+function select_region(g::AbstractGraph, i::Int, n_max::Int, strategy::Symbol)
+    if strategy == :neighbor
+        return select_region_neighbor(g, i, n_max)
+    elseif strategy == :mincut
+        return select_region_mincut(g, i, n_max)
+    else
+        error("Invalid strategy: $strategy")
+    end
+end
+
+function select_region_neighbor(g::AbstractGraph, i::Int, n_max::Int)
+    vs = [i]
+    while length(vs) < n_max
+        nbrs = OptimalBranchingMIS.open_neighbors(g, vs)
+        (length(vs) + length(nbrs) > n_max) && break
+        append!(vs, nbrs)
+    end
+    return vs
+end
+
+function select_region_mincut(args...)
     error("Region selection requires `using KaHyPar`, since it is an extension function.")
 end
 


### PR DESCRIPTION
The previous change breaks the tensor network reducer, since it removed `select_region`, which also includes an approach don't need `KaHyPar`.