### PR TITLE
Allow DataStructures 0.19 in OptimalBranchingCore

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://optimalbranching.github.io/OptimalBranching.jl/dev/)
 [![Build Status](https://github.com/OptimalBranching/OptimalBranching.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/OptimalBranching/OptimalBranching.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/OptimalBranching/OptimalBranching.jl/graph/badge.svg?token=GF1R6ZEVVL)](https://codecov.io/gh/OptimalBranching/OptimalBranching.jl)
+![Agent maintained](https://img.shields.io/badge/maintenance-agent%20maintained-blue)
 
 `OptimalBranching.jl` is a collection of tools for solving combinatorial optimization problems with branch-and-reduce method.
 It is written in Julia and features automatically generated branching rules with provable optimality ([arXiv: 2412.07685](https://arxiv.org/abs/2412.07685)).

--- a/lib/OptimalBranchingCore/Project.toml
+++ b/lib/OptimalBranchingCore/Project.toml
@@ -11,7 +11,7 @@ JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 
 [compat]
 BitBasis = "0.9"
-DataStructures = "0.18.20"
+DataStructures = "0.18.20, 0.19"
 HiGHS = "1.12"
 JuMP = "1.23"
 julia = "1.10"

--- a/lib/OptimalBranchingMIS/src/algorithms/xiao2013_utils.jl
+++ b/lib/OptimalBranchingMIS/src/algorithms/xiao2013_utils.jl
@@ -142,7 +142,7 @@ function first_twin(g::SimpleGraph)
     return nothing
 end
 
-function is_complete_graph(g::SimpleGraph, vertices::Vector)
+function is_complete_graph(g::SimpleGraph, vertices::AbstractVector)
     (length(vertices) <= 1) && return false
     for (u, v) in combinations(vertices, 2)
         (!has_edge(g, u, v)) && return false


### PR DESCRIPTION
OptimalBranchingCore's DataStructures compat excluded the current 0.19 release even though its PriorityQueue usage remains compatible. This widens the bound to retain 0.18.20 support and allow DataStructures 0.19.

Resolving 0.19.6 also selects Graphs 1.15, where `neighbors` returns a read-only `FrozenVector`. The clique predicate only iterates its input, so its signature now accepts `AbstractVector` and preserves the existing behavior for `Vector` callers.

This is the first agent-created maintenance PR for the repository, so it also adds the required maintenance badge.

Validation:
- Julia 1.12.4, DataStructures 0.19.6: OptimalBranchingCore complete tests and doctests passed 175/175; focused greedy merge passed 5/5
- First-head GitHub CI: Core 175/175, root and docs passed; MIS exposed the Graphs 1.15 `FrozenVector` signature incompatibility fixed in the current head
- Current-head CI provides the integration validation because the local MIS rerun was stopped before tests when shared disk free space fell to 168 MiB
- `git diff --check`

The widened compat retains DataStructures 0.18.20, but the full local suite was run specifically against 0.19.6. Existing pre-change CI covers the unchanged 0.18 code path.
