### PR TITLE
Reduce first-call compilation for the default MIS solver

### DIFF
--- a/lib/OptimalBranchingMIS/Project.toml
+++ b/lib/OptimalBranchingMIS/Project.toml
@@ -4,6 +4,7 @@ authors = ["Xuanzhao Gao <xz.gao@connect.ust.hk> and Jin-Guo Liu and Yijia Wang"
 version = "0.2.1"
 
 [deps]
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 EliminateGraphs = "b3ff564c-d3b6-11e9-0ef2-9b4ae9f9cbe1"
 GenericTensorNetworks = "3521c873-ad32-4bb4-b63d-f4f178f42b49"
@@ -18,6 +19,7 @@ KaHyPar = "2a6221f6-aa48-11e9-3542-2d9e0ef01880"
 KaHyParExt = "KaHyPar"
 
 [compat]
+PrecompileTools = "1"
 Combinatorics = "1"
 EliminateGraphs = "0.2"
 GenericTensorNetworks = "3, 4"

--- a/lib/OptimalBranchingMIS/src/OptimalBranchingMIS.jl
+++ b/lib/OptimalBranchingMIS/src/OptimalBranchingMIS.jl
@@ -8,6 +8,7 @@ using Combinatorics
 using EliminateGraphs, EliminateGraphs.Graphs
 using GenericTensorNetworks
 using SparseArrays
+using PrecompileTools: @setup_workload, @compile_workload
 using ProblemReductions: IndependentSet
 
 export MISProblem
@@ -31,5 +32,6 @@ include("tablesolver.jl")
 include("branch.jl")
 
 include("interfaces.jl")
+include("precompile.jl")
 
 end

--- a/lib/OptimalBranchingMIS/src/precompile.jl
+++ b/lib/OptimalBranchingMIS/src/precompile.jl
@@ -1,0 +1,9 @@
+# Compile the default MIS entry points on a small, deterministic cubic graph.
+# Workload setup and execution happen during package precompilation only.
+@setup_workload begin
+    graph = Graphs.random_regular_graph(60, 3; seed=2134)
+    @compile_workload begin
+        mis_size(graph)
+        mis_branch_count(graph)
+    end
+end


### PR DESCRIPTION
A first call to the default MIS solver spends most of its time compiling. Add a PrecompileTools workload for `mis_size` and `mis_branch_count` on a deterministic 60-vertex cubic graph so that typical solver code is cached during package precompilation.

In fresh Julia 1.12.4 processes on this Mac, the same 60-vertex graph returned `(27, 8)` before and after the change. The first measured call fell from 13.36 seconds (13.26 seconds compilation) to 0.12 seconds (0.05 seconds compilation). Warm calls stayed around 0.06–0.07 seconds. These are local measurements, not universal speed guarantees. The tradeoff is additional package precompilation work: rebuilding MIS and the root package took about 22 seconds in this trial. Other graph sizes and custom strategies can still require compilation.

The isolated trial uses PrecompileTools 1.3.4, GenericTensorNetworks 4.1.0, Graphs 1.13.1, ProblemReductions 0.3.5, JuMP 1.31.2 and HiGHS 1.25.2. Shared dependency versions match the baseline environment. Existing compatibility bounds and solver choices are preserved. Full isolated `Pkg.test` passes on Julia 1.12.4: 6,845 MIS assertions and 5 root assertions. GitHub checks are still running. A Julia 1.10.12 resolution trial is blocked by the existing MIS SparseArrays 1.11 lower bound; it did not reach runtime tests, and this PR does not change that bound.

Fixes #19.
