### PR TITLE
Stabilize structural hashing for branching clauses

### DIFF
--- a/lib/OptimalBranchingCore/src/bitbasis.jl
+++ b/lib/OptimalBranchingCore/src/bitbasis.jl
@@ -32,6 +32,11 @@ struct Clause{INT <: Integer}
     end
 end
 
+# BitBasis integer types define explicit value-based one-argument hashes.
+# Combine those field hashes so a Clause hash does not depend on this package's
+# build identity through its inherited generic structural hash.
+Base.hash(c::Clause, h::UInt) = hash(hash(c.val), hash(hash(c.mask), h))
+
 function clause_string(c::Clause{INT}) where INT
     join([iszero(readbit(c.val, i)) ? "¬#$i" : "#$i" for i = 1:bsizeof(INT) if readbit(c.mask, i) == 1], " ∧ ")
 end

--- a/lib/OptimalBranchingCore/test/bitbasis.jl
+++ b/lib/OptimalBranchingCore/test/bitbasis.jl
@@ -49,6 +49,19 @@ end
     c3 = OptimalBranchingCore.gather2(5, c1, c2)
     @test c3 == Clause(LongLongUInt{1}((0b10100,)), LongLongUInt{1}((0b0,)))
     @test length(c3) == 2
+
+    # Equal clauses must behave as the same key independently of object identity.
+    c3_copy = Clause(LongLongUInt{1}((0b10100,)), LongLongUInt{1}((0b0,)))
+    @test hash(c3, UInt(0)) == hash(c3_copy, UInt(0))
+    @test length(Dict(c3 => :first, c3_copy => :second)) == 1
+
+    # Hashing also respects constructor normalization for multiword values.
+    multi_mask = LongLongUInt{2}((0x0f, 0xf0))
+    multi_raw = Clause(multi_mask, LongLongUInt{2}((0xff, 0xff)))
+    multi_normalized = Clause(multi_mask, LongLongUInt{2}((0x0f, 0xf0)))
+    @test multi_raw == multi_normalized
+    @test hash(multi_raw, UInt(0)) == hash(multi_normalized, UInt(0))
+    @test length(Dict(multi_raw => :first, multi_normalized => :second)) == 1
 end
 
 @testset "satellite" begin


### PR DESCRIPTION
`Clause` currently inherits Julia's generic structural hash. Its hash therefore changes with the package build identity, which changes `Dict` key iteration and can map the same seeded random stream to a different branching path.

This adds a structural two-argument hash composed from the value hashes already supplied by the supported BitBasis integer types. Equal clause values now produce the same build-independent hash and candidate order. It also covers equal-content hashing and dictionary-key behavior.

Addresses #45. This addresses the reproduced current-build variance; it does not claim to resolve every historical KaHyPar or GreedyMerge benchmark in that thread.

Validation:
- `OptimalBranchingCore/test/bitbasis.jl`: 29 tests passed in the existing validated dependency environment.
- Six focused equal-content, multiword, normalization, and Dict assertions passed on exact head.
- Three fresh processes on exact head reproduced identical graph, RNG prefix, branching table, 99 candidate identities, candidate ordering, and `(26, 8)` result.
- The same fix applied to the precompile context produced the same clause hashes, candidate ordering, and `(26, 8)` result across three fresh processes.
- The maximal MIS result remains 26. The original baseline branch count changes from 9 to 8 because the fix intentionally stabilizes the previously build-dependent search path.
